### PR TITLE
Enable rayon by default

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,7 +33,7 @@ jobs:
           - macos-latest
           - windows-latest
         features:
-          - ''
+          - '--no-default-features'
           - '--all-features'
     steps:
       - uses: actions/checkout@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,4 +29,5 @@ clap = { version = "4.5.4", features = ["derive"] }
 imageproc = { version = "0.25.0", features = ["display-window"] }
 
 [features]
-rayon = ["dep:rayon"]
+default = ["rayon"]
+rayon = ["dep:rayon", "image/rayon", "imageproc/rayon"]


### PR DESCRIPTION
Makes `rayon` a default crate feature.